### PR TITLE
Simplify access to  MCR-DL

### DIFF
--- a/benchmarks/all_gather.py
+++ b/benchmarks/all_gather.py
@@ -95,7 +95,6 @@ def run_all_gather(local_rank, args):
                 # Delete original mat to avoid OOM
                 del mat
                 get_accelerator().empty_cache()
-                print(f"#######All gather world size : {world_size}")
                 output = torch.zeros(input.nelement() * world_size,
                                      dtype=getattr(torch, args.dtype)).to(get_accelerator().device_name(local_rank))
             except RuntimeError as e:

--- a/benchmarks/all_reduce.py
+++ b/benchmarks/all_reduce.py
@@ -60,10 +60,6 @@ def timed_all_reduce(input, start_event, end_event, args):
 
 
 def run_all_reduce(local_rank, args):
-    # if args.dist == 'torch':
-    #     import torch.distributed as dist
-    # elif args.dist == 'mcr_dl':
-    #     import mcr_dl as dist
     import mcr_dl
     dist = mcr_dl.get_distributed_engine()
 

--- a/benchmarks/all_reduce.py
+++ b/benchmarks/all_reduce.py
@@ -28,10 +28,8 @@ from mcr_dl.cuda_accelerator import get_accelerator
 
 
 def timed_all_reduce(input, start_event, end_event, args):
-    if args.dist == 'torch':
-        import torch.distributed as dist
-    elif args.dist == 'mcr_dl':
-        import mcr_dl as dist
+    import mcr_dl
+    dist = mcr_dl.get_distributed_engine()
 
     sync_all()
     # Warmups, establish connections, etc.
@@ -62,10 +60,12 @@ def timed_all_reduce(input, start_event, end_event, args):
 
 
 def run_all_reduce(local_rank, args):
-    if args.dist == 'torch':
-        import torch.distributed as dist
-    elif args.dist == 'mcr_dl':
-        import mcr_dl as dist
+    # if args.dist == 'torch':
+    #     import torch.distributed as dist
+    # elif args.dist == 'mcr_dl':
+    #     import mcr_dl as dist
+    import mcr_dl
+    dist = mcr_dl.get_distributed_engine()
 
     # Prepare benchmark header
     print_header(args, 'all_reduce')
@@ -125,7 +125,8 @@ def run_all_reduce(local_rank, args):
 
 
 if __name__ == "__main__":
+    import mcr_dl
     args = benchmark_parser().parse_args()
     rank = args.local_rank
-    init_processes(local_rank=rank, args=args)
+    mcr_dl.init_processes(args.dist, args.backend)
     run_all_reduce(local_rank=rank, args=args)

--- a/benchmarks/all_to_all.py
+++ b/benchmarks/all_to_all.py
@@ -28,10 +28,7 @@ from mcr_dl.cuda_accelerator import get_accelerator
 
 
 def timed_all_to_all(input, output, start_event, end_event, args):
-    if args.dist == 'torch':
-        import torch.distributed as dist
-    elif args.dist == 'mcr_dl':
-        import mcr_dl as dist
+    dist = mcr_dl.get_distributed_engine()
 
     sync_all()
     # Warmups, establish connections, etc.
@@ -62,10 +59,7 @@ def timed_all_to_all(input, output, start_event, end_event, args):
 
 
 def run_all_to_all(local_rank, args):
-    if args.dist == 'torch':
-        import torch.distributed as dist
-    elif args.dist == 'mcr_dl':
-        import mcr_dl as dist
+    dist = mcr_dl.get_distributed_engine()
 
     world_size = dist.get_world_size()
     global_rank = dist.get_rank()
@@ -147,5 +141,5 @@ def run_all_to_all(local_rank, args):
 if __name__ == "__main__":
     args = benchmark_parser().parse_args()
     rank = args.local_rank
-    init_processes(local_rank=rank, args=args)
+    mcr_dl.init_processes(args.dist, args.backend)
     run_all_to_all(local_rank=rank, args=args)

--- a/benchmarks/broadcast.py
+++ b/benchmarks/broadcast.py
@@ -28,10 +28,7 @@ from mcr_dl.cuda_accelerator import get_accelerator
 
 
 def timed_broadcast(input, start_event, end_event, args):
-    if args.dist == 'torch':
-        import torch.distributed as dist
-    elif args.dist == 'mcr_dl':
-        import mcr_dl as dist
+    dist = mcr_dl.get_distributed_engine()
 
     sync_all()
     # Warmups, establish connections, etc.
@@ -62,10 +59,7 @@ def timed_broadcast(input, start_event, end_event, args):
 
 
 def run_broadcast(local_rank, args):
-    if args.dist == 'torch':
-        import torch.distributed as dist
-    elif args.dist == 'mcr_dl':
-        import mcr_dl as dist
+    dist = mcr_dl.get_distributed_engine()
 
     # Prepare benchmark header
     print_header(args, 'broadcast')
@@ -125,5 +119,5 @@ def run_broadcast(local_rank, args):
 if __name__ == "__main__":
     args = benchmark_parser().parse_args()
     rank = args.local_rank
-    init_processes(local_rank=rank, args=args)
+    mcr_dl.init_processes(args.dist, args.backend)
     run_broadcast(local_rank=rank, args=args)

--- a/benchmarks/pt2pt.py
+++ b/benchmarks/pt2pt.py
@@ -28,10 +28,7 @@ from mcr_dl.cuda_accelerator import get_accelerator
 
 
 def timed_pt2pt(input, start_event, end_event, args):
-    if args.dist == 'torch':
-        import torch.distributed as dist
-    elif args.dist == 'mcr_dl':
-        import mcr_dl as dist
+    dist = mcr_dl.get_distributed_engine()
 
     sync_all()
     # Warmups, establish connections, etc.
@@ -81,10 +78,7 @@ def timed_pt2pt(input, start_event, end_event, args):
 
 
 def run_pt2pt(local_rank, args):
-    if args.dist == 'torch':
-        import torch.distributed as dist
-    elif args.dist == 'mcr_dl':
-        import mcr_dl as dist
+    dist = mcr_dl.get_distributed_engine()
 
     # Prepare benchmark header
     print_header(args, 'pt2pt')
@@ -144,5 +138,5 @@ def run_pt2pt(local_rank, args):
 if __name__ == "__main__":
     args = benchmark_parser().parse_args()
     rank = args.local_rank
-    init_processes(local_rank=rank, args=args)
+    mcr_dl.init_processes(args.dist, args.backend)
     run_pt2pt(local_rank=rank, args=args)

--- a/benchmarks/run_all.py
+++ b/benchmarks/run_all.py
@@ -33,7 +33,7 @@ from constants import *
 # For importing
 def main(args, rank):
 
-    init_processes(local_rank=rank, args=args)
+    mcr_dl.init_processes(args.dist, args.backend)
 
     ops_to_run = []
     if args.all_reduce:

--- a/mcr_dl/mpi.py
+++ b/mcr_dl/mpi.py
@@ -72,12 +72,13 @@ class MPIBackend(Backend):
         pass
 
     def new_group(self, ranks):
-        # TODO: Change this to use comm_op.new_group when the impl. is ready.
+        # TODO: Change this to use self.mpi_comm_op.new_group(ranks) when the impl. is ready.
         if not torch.distributed.is_initialized():
             from mcr_dl.torch import TorchBackend
-            d = TorchBackend(rank=self.rank, size=self.size)
+            d = TorchBackend(rank=self.rank, world_size=self.size)
         logger.info(f"new group called with {ranks}")
         return torch.distributed.new_group(ranks)
+        # return self.mpi_comm_op.new_group(ranks)
 
     def get_rank(self, group=None):
         return self.mpi_comm_op.get_rank(0)

--- a/mcr_dl/torch.py
+++ b/mcr_dl/torch.py
@@ -23,6 +23,7 @@ from mcr_dl import utils
 from .utils import *
 from .backend import *
 from .comm import *
+from .constants import default_pg_timeout
 
 DS_COMM_ALL_GATHER_OFF = False
 DS_COMM_REDUCE_SCATTER_OFF = False
@@ -119,7 +120,7 @@ class TorchBackend(Backend):
         needed.
     """
 
-    def __init__(self, backend, timeout, init_method, rank=-1, world_size=-1, name='torch'):
+    def __init__(self, backend="mpi", init_method = None, timeout = default_pg_timeout, rank=-1, world_size=-1, name='torch'):
         super(TorchBackend, self).__init__()
         self.has_all_reduce_coalesced = has_all_reduce_coalesced()
         self.has_coalescing_manager = has_coalescing_manager()
@@ -131,7 +132,7 @@ class TorchBackend(Backend):
         # The idea is to fake that dist backend is initialized even when
         # it is not so we can run on a single GPU without doing any init_process_group
         self.single_gpu_mode = True
-        self.init_process_group(backend, timeout, init_method, rank, world_size)
+        self.init_process_group(backend=backend, init_method=init_method, timeout= timeout, rank=rank, world_size= world_size)
 
     @classmethod
     def get_all_gather_function(self):

--- a/tests/main.py
+++ b/tests/main.py
@@ -20,7 +20,7 @@ import os
 import time
 import argparse
 import torch
-
+import mcr_dl
 from mcr_dl.constants import TORCH_DISTRIBUTED_DEFAULT_PORT
 from common import set_accelerator_visible
 from mcr_dl.cuda_accelerator import get_accelerator
@@ -32,38 +32,8 @@ parser.add_argument("--backend", choices=['mpi', 'nccl'], help = "Backend")
 parser.add_argument("--dist", choices=['mcr_dl', 'torch'], help = "torch.distributed or mcr-dl for distributed")
 args = parser.parse_args()
 
-def init_torch_distributed(backend):
-    global dist
-    import torch.distributed as dist
-    if backend == 'nccl':
-        mpi_discovery()
-    elif backend == 'mpi':
-        set_mpi_dist_environemnt()
-    dist.init_process_group(backend)
-    local_rank = int(os.environ['LOCAL_RANK'])
-    get_accelerator().set_device(local_rank)
-
-
-def init_mcr_dl_comm(backend):
-    global dist
-    import mcr_dl
-    import mcr_dl as dist
-    mcr_dl.init_distributed(dist_backend=backend, use_mcr_dl=True)
-    local_rank = int(os.environ['LOCAL_RANK'])
-    #get_accelerator().set_device(local_rank)
-
-
-def init_processes(args_dist, args_backend):
-    print(f'Comm : {args_dist}  Backend : {args_backend}')
-    if args_dist == 'mcr_dl':
-        init_mcr_dl_comm(args_backend)
-    elif args_dist == 'torch':
-        init_torch_distributed(args_backend)
-    else:
-        print(f"distributed framework {args_dist} not supported")
-        exit(0)
-
 def all_reduce():
+    dist = mcr_dl.get_distributed_engine()
     x = torch.ones(1, 3).to(get_accelerator().device_name()) * (dist.get_rank() + 1)
     sum_of_ranks = (dist.get_world_size() * (dist.get_world_size() + 1)) // 2
     result = torch.ones(1, 3).to(get_accelerator().device_name()) * sum_of_ranks
@@ -71,6 +41,7 @@ def all_reduce():
     assert torch.all(x == result)
 
 def all_reduce_benchmark():
+    dist = mcr_dl.get_distributed_engine()
     start_events = [torch.cuda.Event(enable_timing=True) for _ in range(2, 30)]
     end_events = [torch.cuda.Event(enable_timing=True) for _ in range(2, 30)]
     rank = dist.get_rank()
@@ -101,7 +72,7 @@ def all_reduce_benchmark():
 
 if __name__ == "__main__":
     set_accelerator_visible()
-    init_processes(args_dist=args.dist, args_backend=args.backend)
+    mcr_dl.init_processes(dist_engine = args.dist, dist_backend = args.backend)
     # all_reduce()
     all_reduce_benchmark()
 


### PR DESCRIPTION
**Previously:**
1. Initialization for distribution requires the user to make application-level changes for different backends (nccl/mpi) in each distributed module (torch/mcr-dl), as shown here: https://github.com/OSU-Nowlab/MCR-DL/blob/main/benchmarks/utils.py#L61.
2. The application code becomes messy when accessing the distributed module, and it also requires exporting args or knowing args.dist every time when accessing dist, as shown below:
```
if args.dist == 'torch':
    import torch.distributed as dist
elif args.dist == 'mcr_dl':
    import mcr_dl as dist
```

**Now:**
1. Initialize dist using `mcr_dl.init_processes()` replacing `torch.distributed.init_process_group()` in application.
2. Access dist by `dist = mcr_dl.get_distributed_engine()` instead of `torch.distributed as dist` in application.